### PR TITLE
Master

### DIFF
--- a/dcp-tokenomics.html
+++ b/dcp-tokenomics.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>FILM Token Economics & Reward Strategies</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 20px;
+            line-height: 1.6;
+        }
+        .calculator-link {
+            background: #f5f5f5;
+            padding: 20px;
+            margin: 20px 0;
+            border-radius: 8px;
+            border-left: 4px solid #0066cc;
+        }
+        .calculator-link h3 {
+            margin-top: 0;
+            color: #0066cc;
+        }
+        .calculator-link a {
+            color: #0066cc;
+            text-decoration: none;
+            font-weight: bold;
+        }
+        .calculator-link a:hover {
+            text-decoration: underline;
+        }
+        .overview {
+            background: #e9f5ff;
+            padding: 25px;
+            border-radius: 8px;
+            margin-bottom: 30px;
+        }
+    </style>
+</head>
+<body>
+    <h1>FILM Token Economics & Reward Strategies</h1>
+
+    <div class="overview">
+        <h2>Ecosystem Overview</h2>
+        <p>The FILM token ecosystem employs multiple reward mechanisms to incentivize participation, quality contributions, and long-term engagement. These mechanisms work together to create a sustainable token economy that rewards different types of participation while maintaining token value through strategic distribution.</p>
+    </div>
+
+    <div class="calculator-link">
+        <h3>1. Film Reward Strategy Analysis</h3>
+        <p>The foundation of the ecosystem's reward structure, focusing on long-term token distribution and value creation through strategic staking and participation.</p>
+        <p><strong>Key Features:</strong></p>
+        <ul>
+            <li>Strategic token distribution modeling</li>
+            <li>Long-term value analysis</li>
+            <li>Staking reward calculations</li>
+        </ul>
+        <a href="https://film-reward-strategy-analysis.netlify.app/" target="_blank">&rarr; Open Film Reward Strategy Calculator</a>
+    </div>
+
+    <div class="calculator-link">
+        <h3>2. Creative Query Rewards</h3>
+        <p>A reputation-based system that rewards quality contributions to creative queries, combining stake amounts with reputation multipliers to determine rewards.</p>
+        <p><strong>Key Features:</strong></p>
+        <ul>
+            <li>Reputation tiers (1.0x - 1.5x multipliers)</li>
+            <li>Stake-weighted rewards</li>
+            <li>Dynamic bounty distribution</li>
+        </ul>
+        <a href="https://creative-query-rewards-calculator.netlify.app/" target="_blank">&rarr; Open Creative Query Calculator</a>
+    </div>
+
+    <div class="calculator-link">
+        <h3>3. DCP Quiz Game Rewards</h3>
+        <p>A daily engagement mechanism that rewards knowledge and participation through quiz completion, distributing from a fixed daily pool of 150 FILM tokens.</p>
+        <p><strong>Key Features:</strong></p>
+        <ul>
+            <li>Performance-based rewards</li>
+            <li>Daily reward pool</li>
+            <li>Minimum participation threshold</li>
+        </ul>
+        <a href="https://quiz-game-rewards-tool.netlify.app/" target="_blank">&rarr; Open Quiz Game Calculator</a>
+    </div>
+
+    <div class="overview">
+        <h2>Economic Integration</h2>
+        <p>These three mechanisms work together to create a balanced token economy:</p>
+        <ul>
+            <li><strong>Long-term Value:</strong> The reward strategy analysis ensures sustainable token distribution and value preservation.</li>
+            <li><strong>Quality Contributions:</strong> Creative query rewards incentivize high-quality participation and expertise building through reputation mechanics.</li>
+            <li><strong>Daily Engagement:</strong> The quiz system maintains regular participation and knowledge building with smaller, more frequent rewards.</li>
+        </ul>
+        <p>Together, these systems create multiple engagement paths while maintaining token scarcity and encouraging both short-term participation and long-term commitment to the ecosystem.</p>
+    </div>
+
+    <div class="overview">
+        <h2>Reputation System</h2>
+        <p>Reputation in the DCP ecosystem functions as a non-transferable metric of user engagement and expertise, similar to a soulbound NFT. Unlike $FILM tokens, Reputation cannot be bought, sold, or transferred between users, making it a pure measure of individual contribution and participation.</p>
+        
+        <h3>Reputation Building Activities:</h3>
+        <ul>
+            <li><strong>Review Quality:</strong> 
+                <ul>
+                    <li>Reviews aligning with experienced reviewer consensus can earn up to 100 reputation points</li>
+                    <li>Significantly deviating reviews can lose up to 10 reputation points</li>
+                    <li>System uses top 10% of reviews as quality benchmark</li>
+                </ul>
+            </li>
+            <li><strong>Review Timing:</strong>
+                <ul>
+                    <li>Early reviewers receive maximum timing score (1.0)</li>
+                    <li>Later reviews receive diminishing scores (down to 0.001)</li>
+                </ul>
+            </li>
+        </ul>
+
+        <h3>Review Weight Components:</h3>
+        <ul>
+            <li><strong>Stake Weight (40%):</strong> Based on staked amount relative to other reviewers</li>
+            <li><strong>Reputation Weight (40%):</strong> Based on accumulated reputation compared to other reviewers</li>
+            <li><strong>Timing Weight (10%):</strong> Based on how early the review is submitted</li>
+            <li><strong>Holdings Weight (5%):</strong> Based on token holdings relative to total supply</li>
+            <li><strong>Stake Ratio Weight (5%):</strong> Based on stake amount relative to personal holdings</li>
+        </ul>
+
+        <p>This system encourages thoughtful, timely participation while rewarding both expertise (reputation) and commitment (stake). Growth is proportional to how well assessments align with the median evaluation, promoting quality contributions to the ecosystem.</p>
+    </div>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -78,9 +78,9 @@
                     <a href="statham.html" class="text-blue-500 hover:underline">Learn more</a>
                 </div>
                 <div class="card p-4 bg-white rounded-lg shadow-lg">
-                    <h2 class="text-xl font-semibold mb-2">Evil Testing</h2>
-                    <p class="mb-4">Well motivated anti-heroes.</p>
-                    <a href="evil.html" class="text-blue-500 hover:underline">Learn more</a>
+                    <h2 class="text-xl font-semibold mb-2">DCP Tokenomics</h2>
+                    <p class="mb-4">Explore $FILM token economics.</p>
+                    <a href="dcp-tokenomics.html" class="text-blue-500 hover:underline">Learn more</a>
                 </div>
             </div>
         </section>

--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
             <span>Validator Nodes</span> · 
             <span>Smart Contracts</span> · 
             <span>Degen UX Exploration</span>
+            <span>NFTs</span>
         </p>
     </header>
     


### PR DESCRIPTION
add DCP tokenomics card

## Summary by Sourcery

Add a DCP Tokenomics card to the main page and create a comprehensive HTML document detailing the FILM token's economic strategies and reward mechanisms.

New Features:
- Introduce a new DCP Tokenomics card to the main page, highlighting the $FILM token economics.

Documentation:
- Add a new HTML page detailing the FILM Token Economics and Reward Strategies, including sections on ecosystem overview, reward strategy analysis, creative query rewards, quiz game rewards, economic integration, and the reputation system.